### PR TITLE
[Feat] 프로필 정보 조회 업데이트

### DIFF
--- a/src/main/java/com/sevenstars/roome/domain/profile/response/ProfileResponse.java
+++ b/src/main/java/com/sevenstars/roome/domain/profile/response/ProfileResponse.java
@@ -61,10 +61,12 @@ public class ProfileResponse {
     public static class Genre {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static Genre from(Element genre) {
             return new Genre(genre.getId(),
-                    StringUtils.hasText(genre.getEmoji()) ? genre.getEmoji() + " " + genre.getTitle() : genre.getTitle());
+                    StringUtils.hasText(genre.getEmoji()) ? genre.getEmoji() + " " + genre.getTitle() : genre.getTitle(),
+                    genre.getTitle());
         }
     }
 
@@ -73,10 +75,12 @@ public class ProfileResponse {
     public static class Strength {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static Strength from(Element strength) {
             return new Strength(strength.getId(),
-                    StringUtils.hasText(strength.getEmoji()) ? strength.getEmoji() + " " + strength.getTitle() : strength.getTitle());
+                    StringUtils.hasText(strength.getEmoji()) ? strength.getEmoji() + " " + strength.getTitle() : strength.getTitle(),
+                    strength.getTitle());
         }
     }
 
@@ -85,10 +89,12 @@ public class ProfileResponse {
     public static class ImportantFactor {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static ImportantFactor from(Element importantFactor) {
             return new ImportantFactor(importantFactor.getId(),
-                    StringUtils.hasText(importantFactor.getEmoji()) ? importantFactor.getEmoji() + " " + importantFactor.getSubTitle() : importantFactor.getSubTitle());
+                    StringUtils.hasText(importantFactor.getEmoji()) ? importantFactor.getEmoji() + " " + importantFactor.getSubTitle() : importantFactor.getSubTitle(),
+                    importantFactor.getSubTitle());
         }
     }
 
@@ -97,10 +103,12 @@ public class ProfileResponse {
     public static class HorrorThemePosition {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static HorrorThemePosition from(Element horrorThemePosition) {
             return new HorrorThemePosition(horrorThemePosition.getId(),
-                    StringUtils.hasText(horrorThemePosition.getEmoji()) ? horrorThemePosition.getEmoji() + " " + horrorThemePosition.getTitle() : horrorThemePosition.getTitle());
+                    StringUtils.hasText(horrorThemePosition.getEmoji()) ? horrorThemePosition.getEmoji() + " " + horrorThemePosition.getTitle() : horrorThemePosition.getTitle(),
+                    horrorThemePosition.getTitle());
         }
     }
 
@@ -109,10 +117,12 @@ public class ProfileResponse {
     public static class HintUsagePreference {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static HintUsagePreference from(Element hintUsagePreference) {
             return new HintUsagePreference(hintUsagePreference.getId(),
-                    StringUtils.hasText(hintUsagePreference.getEmoji()) ? hintUsagePreference.getEmoji() + " " + hintUsagePreference.getTitle() : hintUsagePreference.getTitle());
+                    StringUtils.hasText(hintUsagePreference.getEmoji()) ? hintUsagePreference.getEmoji() + " " + hintUsagePreference.getTitle() : hintUsagePreference.getTitle(),
+                    hintUsagePreference.getTitle());
         }
     }
 
@@ -121,10 +131,12 @@ public class ProfileResponse {
     public static class DeviceLockPreference {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static DeviceLockPreference from(Element deviceLockPreference) {
             return new DeviceLockPreference(deviceLockPreference.getId(),
-                    StringUtils.hasText(deviceLockPreference.getEmoji()) ? deviceLockPreference.getEmoji() + " " + deviceLockPreference.getTitle() : deviceLockPreference.getTitle());
+                    StringUtils.hasText(deviceLockPreference.getEmoji()) ? deviceLockPreference.getEmoji() + " " + deviceLockPreference.getTitle() : deviceLockPreference.getTitle(),
+                    deviceLockPreference.getTitle());
         }
     }
 
@@ -133,10 +145,12 @@ public class ProfileResponse {
     public static class Activity {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static Activity from(Element activity) {
             return new Activity(activity.getId(),
-                    StringUtils.hasText(activity.getEmoji()) ? activity.getEmoji() + " " + activity.getTitle() : activity.getTitle());
+                    StringUtils.hasText(activity.getEmoji()) ? activity.getEmoji() + " " + activity.getTitle() : activity.getTitle(),
+                    activity.getTitle());
         }
     }
 
@@ -145,10 +159,12 @@ public class ProfileResponse {
     public static class DislikedFactor {
         private final Long id;
         private final String title;
+        private final String text;
 
         public static DislikedFactor from(Element dislikedFactor) {
             return new DislikedFactor(dislikedFactor.getId(),
-                    StringUtils.hasText(dislikedFactor.getEmoji()) ? dislikedFactor.getEmoji() + " " + dislikedFactor.getTitle() : dislikedFactor.getTitle());
+                    StringUtils.hasText(dislikedFactor.getEmoji()) ? dislikedFactor.getEmoji() + " " + dislikedFactor.getTitle() : dislikedFactor.getTitle(),
+                    dislikedFactor.getTitle());
         }
     }
 

--- a/src/test/java/com/sevenstars/roome/docs/user/ProfileControllerDocsTest.java
+++ b/src/test/java/com/sevenstars/roome/docs/user/ProfileControllerDocsTest.java
@@ -11,7 +11,6 @@ import com.sevenstars.roome.domain.profile.response.ProfileResponse;
 import com.sevenstars.roome.domain.profile.service.ProfileService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import java.util.List;
@@ -26,7 +25,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -205,28 +205,28 @@ public class ProfileControllerDocsTest extends RestDocsTest {
 
         // Given
         List<ProfileResponse.Genre> genres = List.of(
-                new ProfileResponse.Genre(9L, "미스터리"),
-                new ProfileResponse.Genre(15L, "SF"));
+                new ProfileResponse.Genre(9L, "미스터리", "미스터리"),
+                new ProfileResponse.Genre(15L, "SF", "SF"));
 
         List<ProfileResponse.Strength> strengths = List.of(
-                new ProfileResponse.Strength(4L, "집중력"),
-                new ProfileResponse.Strength(8L, "침착함"));
+                new ProfileResponse.Strength(4L, "집중력", "집중력"),
+                new ProfileResponse.Strength(8L, "침착함", "침착함"));
 
         List<ProfileResponse.ImportantFactor> importantFactors = List.of(
-                new ProfileResponse.ImportantFactor(3L, "명확한 개연성"),
-                new ProfileResponse.ImportantFactor(7L, "논리적인 문제"));
+                new ProfileResponse.ImportantFactor(3L, "명확한 개연성", "명확한 개연성"),
+                new ProfileResponse.ImportantFactor(7L, "논리적인 문제", "논리적인 문제"));
 
-        ProfileResponse.HorrorThemePosition horrorThemePosition = new ProfileResponse.HorrorThemePosition(4L, "마지모탱");
+        ProfileResponse.HorrorThemePosition horrorThemePosition = new ProfileResponse.HorrorThemePosition(4L, "마지모탱", "마지모탱");
 
-        ProfileResponse.HintUsagePreference hintUsagePreference = new ProfileResponse.HintUsagePreference(2L, "최소한의 힌트만");
+        ProfileResponse.HintUsagePreference hintUsagePreference = new ProfileResponse.HintUsagePreference(2L, "최소한의 힌트만", "최소한의 힌트만");
 
-        ProfileResponse.DeviceLockPreference deviceLockPreference = new ProfileResponse.DeviceLockPreference(1L, "장치");
+        ProfileResponse.DeviceLockPreference deviceLockPreference = new ProfileResponse.DeviceLockPreference(1L, "장치", "장치");
 
-        ProfileResponse.Activity activity = new ProfileResponse.Activity(3L, "낮은 활동성");
+        ProfileResponse.Activity activity = new ProfileResponse.Activity(3L, "낮은 활동성", "낮은 활동성");
 
         List<ProfileResponse.DislikedFactor> dislikedFactors = List.of(
-                new ProfileResponse.DislikedFactor(2L, "노가다 문제"),
-                new ProfileResponse.DislikedFactor(6L, "높은 난이도"));
+                new ProfileResponse.DislikedFactor(2L, "노가다 문제", "노가다 문제"),
+                new ProfileResponse.DislikedFactor(6L, "높은 난이도", "높은 난이도"));
 
         ProfileResponse.Color color = new ProfileResponse.Color(4L,
                 "Gradient Purple",
@@ -274,6 +274,8 @@ public class ProfileControllerDocsTest extends RestDocsTest {
                                                 .description("선호 장르 ID"),
                                         fieldWithPath("data.preferredGenres[].title").type(JsonFieldType.STRING)
                                                 .description("선호 장르 제목"),
+                                        fieldWithPath("data.preferredGenres[].text").type(JsonFieldType.STRING)
+                                                .description("선호 장르 텍스트"),
                                         fieldWithPath("data.mbti").type(JsonFieldType.STRING)
                                                 .description("MBTI"),
                                         fieldWithPath("data.userStrengths[]").type(JsonFieldType.ARRAY)
@@ -282,34 +284,48 @@ public class ProfileControllerDocsTest extends RestDocsTest {
                                                 .description("사용자 강점 ID"),
                                         fieldWithPath("data.userStrengths[].title").type(JsonFieldType.STRING)
                                                 .description("사용자 강점 제목"),
+                                        fieldWithPath("data.userStrengths[].text").type(JsonFieldType.STRING)
+                                                .description("사용자 강점 텍스트"),
                                         fieldWithPath("data.themeImportantFactors[]").type(JsonFieldType.ARRAY)
                                                 .description("테마 중요 요소 목록"),
                                         fieldWithPath("data.themeImportantFactors[].id").type(JsonFieldType.NUMBER)
                                                 .description("테마 중요 요소 ID"),
                                         fieldWithPath("data.themeImportantFactors[].title").type(JsonFieldType.STRING)
                                                 .description("테마 중요 요소 제목"),
+                                        fieldWithPath("data.themeImportantFactors[].text").type(JsonFieldType.STRING)
+                                                .description("테마 중요 요소 텍스트"),
                                         fieldWithPath("data.horrorThemePosition.id").type(JsonFieldType.NUMBER)
                                                 .description("공포 테마 포지션 ID"),
                                         fieldWithPath("data.horrorThemePosition.title").type(JsonFieldType.STRING)
                                                 .description("공포 테마 포지션 제목"),
+                                        fieldWithPath("data.horrorThemePosition.text").type(JsonFieldType.STRING)
+                                                .description("공포 테마 포지션 텍스트"),
                                         fieldWithPath("data.hintUsagePreference.id").type(JsonFieldType.NUMBER)
                                                 .description("힌트 사용 선호도 ID"),
                                         fieldWithPath("data.hintUsagePreference.title").type(JsonFieldType.STRING)
                                                 .description("힌트 사용 선호도 제목"),
+                                        fieldWithPath("data.hintUsagePreference.text").type(JsonFieldType.STRING)
+                                                .description("힌트 사용 선호도 텍스트"),
                                         fieldWithPath("data.deviceLockPreference.id").type(JsonFieldType.NUMBER)
                                                 .description("장치 자물쇠 선호도 ID"),
                                         fieldWithPath("data.deviceLockPreference.title").type(JsonFieldType.STRING)
                                                 .description("장치 자물쇠 선호도 제목"),
+                                        fieldWithPath("data.deviceLockPreference.text").type(JsonFieldType.STRING)
+                                                .description("장치 자물쇠 선호도 텍스트"),
                                         fieldWithPath("data.activity.id").type(JsonFieldType.NUMBER)
                                                 .description("활동성 ID"),
                                         fieldWithPath("data.activity.title").type(JsonFieldType.STRING)
                                                 .description("활동성 제목"),
+                                        fieldWithPath("data.activity.text").type(JsonFieldType.STRING)
+                                                .description("활동성 텍스트"),
                                         fieldWithPath("data.themeDislikedFactors[]").type(JsonFieldType.ARRAY)
                                                 .description("싫어하는 요소 목록"),
                                         fieldWithPath("data.themeDislikedFactors[].id").type(JsonFieldType.NUMBER)
                                                 .description("싫어하는 요소 ID"),
                                         fieldWithPath("data.themeDislikedFactors[].title").type(JsonFieldType.STRING)
                                                 .description("싫어하는 요소 제목"),
+                                        fieldWithPath("data.themeDislikedFactors[].text").type(JsonFieldType.STRING)
+                                                .description("싫어하는 요소 텍스트"),
                                         fieldWithPath("data.color.id").type(JsonFieldType.NUMBER)
                                                 .description("색상 ID"),
                                         fieldWithPath("data.color.title").type(JsonFieldType.STRING)


### PR DESCRIPTION
# 개요
- 프로필 정보 조회 API에 텍스트 필드 추가

# 변경 내용
- 기존 타이틀 필드는 이모지 + 텍스트임
- 프로필 화면에서는 프로필 항목들이 이모지 없는 텍스트만 출력되므로, 프로필 정보 조회 API에 텍스트 필드 추가함