### PR TITLE
[Feat] 회원 탈퇴 기능 업데이트

### DIFF
--- a/src/main/java/com/sevenstars/roome/domain/profile/repository/ProfileElementRepository.java
+++ b/src/main/java/com/sevenstars/roome/domain/profile/repository/ProfileElementRepository.java
@@ -1,6 +1,7 @@
 package com.sevenstars.roome.domain.profile.repository;
 
 import com.sevenstars.roome.domain.profile.entity.ElementType;
+import com.sevenstars.roome.domain.profile.entity.Profile;
 import com.sevenstars.roome.domain.profile.entity.ProfileElement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface ProfileElementRepository extends JpaRepository<ProfileElement, Long> {
+
+    List<ProfileElement> findByProfile(Profile profile);
 
     @Query("SELECT pe FROM ProfileElement pe " +
             "JOIN FETCH pe.element e " +

--- a/src/main/java/com/sevenstars/roome/domain/user/entity/User.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/entity/User.java
@@ -36,8 +36,6 @@ public class User extends BaseTimeEntity {
 
     private String imageUrl;
 
-    private Boolean withdrawal;
-
     public User(String serviceId, String serviceUserId, String email) {
         this.state = TERMS_AGREEMENT;
         this.serviceId = serviceId;
@@ -45,7 +43,6 @@ public class User extends BaseTimeEntity {
         this.email = email;
         this.nickname = "";
         this.imageUrl = "";
-        this.withdrawal = false;
     }
 
     public void updateNickname(String nickname) {
@@ -70,10 +67,6 @@ public class User extends BaseTimeEntity {
 
     public void updateEmail(String email) {
         this.email = email;
-    }
-
-    public void withdraw() {
-        this.withdrawal = true;
     }
 
     public void validateNickname(String nickname) {

--- a/src/main/java/com/sevenstars/roome/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/repository/UserRepository.java
@@ -7,9 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByIdAndWithdrawalIsFalse(Long id);
+    Optional<User> findByServiceIdAndServiceUserId(String serviceId, String serviceUserId);
 
-    Optional<User> findByServiceIdAndServiceUserIdAndWithdrawalIsFalse(String serviceId, String serviceUserId);
-
-    boolean existsByNicknameAndWithdrawalIsFalse(String nickname);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/sevenstars/roome/global/auth/service/AbstractLoginService.java
+++ b/src/main/java/com/sevenstars/roome/global/auth/service/AbstractLoginService.java
@@ -77,7 +77,6 @@ public abstract class AbstractLoginService {
             revokeToken(code);
         }
 
-        tokenService.delete(id);
         userService.withdraw(id);
     }
 

--- a/src/main/java/com/sevenstars/roome/global/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sevenstars/roome/global/jwt/filter/JwtAuthorizationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 Authentication authentication = tokenProvider.getAuthentication(userId);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception exception) {
-                log.error("Token authentication failed, {}", exception.getMessage());
+                log.error("Token authentication failed, {}", request.getRequestURL());
             }
         }
 

--- a/src/main/java/com/sevenstars/roome/global/jwt/service/JwtTokenService.java
+++ b/src/main/java/com/sevenstars/roome/global/jwt/service/JwtTokenService.java
@@ -28,7 +28,7 @@ public class JwtTokenService {
     @Transactional
     public TokenResponse issue(Long userId) {
 
-        User user = userRepository.findByIdAndWithdrawalIsFalse(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomClientErrorException(USER_NOT_FOUND));
 
         String token = tokenProvider.createToken(userId);
@@ -51,7 +51,7 @@ public class JwtTokenService {
         Claims claims = tokenProvider.verifyRefreshToken(token);
         Long userId = Long.valueOf(claims.getSubject());
 
-        User user = userRepository.findByIdAndWithdrawalIsFalse(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomClientErrorException(USER_NOT_FOUND));
 
         RefreshToken refreshToken = refreshTokenRepository.findByUser(user)
@@ -72,7 +72,7 @@ public class JwtTokenService {
     @Transactional
     public void delete(Long userId) {
 
-        User user = userRepository.findByIdAndWithdrawalIsFalse(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomClientErrorException(USER_NOT_FOUND));
 
         refreshTokenRepository.findByUser(user)

--- a/src/test/java/com/sevenstars/roome/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sevenstars/roome/domain/user/service/UserServiceTest.java
@@ -75,7 +75,6 @@ class UserServiceTest {
         Assertions.assertThat(user.getServiceUserId()).isEqualTo(serviceUserId);
         Assertions.assertThat(user.getEmail()).isEqualTo(email);
         Assertions.assertThat(user.getNickname()).isEqualTo("");
-        Assertions.assertThat(user.getWithdrawal()).isFalse();
         Assertions.assertThat(user.getState()).isEqualTo(TERMS_AGREEMENT);
     }
 


### PR DESCRIPTION
# 개요
- 회원탈퇴시 모든 개인 정보를 즉시 삭제하도록 변경
- 아래 법에서 해당하는 부분이 없으므로 개인정보 즉시 삭제
  - 대금결제 및 재화 등의 공급에 관한 기록: 5년(전자상거래 등에서의 소비자보호에 관한 법률)
  - 계약 또는 청약철회 등에 관한 기록: 5년(전자상거래 등에서의 소비자보호에 관한 법률)
  - 소비자의 불만 또는 분쟁처리에 관한 기록:  3년(전자상거래 등에서의 소비자보호에 관한 법률)
  - 표시, 광고에 관한 기록: 6개월 (전자상거래 등에서의 소비자보호에 관한 법률)
  - 웹사이트 방문기록: 3개월 (통신비밀 보호법)
- 웹사이트 방문기록은 웹서버 로그로 대체함

# 변경 내용
- 회원탈퇴시 모든 정보 삭제
  - 약관 동의 정보
  - 사용자 이미지(AWS S3 스토리지에 존재)
  - 프로필 정보
  - 사용자 정보
- users 테이블 withdrawal 컬럼 삭제
- 사용자 조회 쿼리 수정