### PR TITLE
[Feat] 공개 프로필 조회 기능 추가, 닉네임 조건 변경

### DIFF
--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -177,3 +177,33 @@ include::{snippets}/user-controller-docs-test/delete-image/request-body.adoc[]
 ==== 6. HTTP Response Body
 include::{snippets}/user-controller-docs-test/delete-image/response-body.adoc[]
 include::{snippets}/user-controller-docs-test/delete-image/response-fields.adoc[]
+
+=== 사용자 프로필 조회
+
+==== 1. Curl Request
+include::{snippets}/user-controller-docs-test/get-profile/curl-request.adoc[]
+
+==== 2. HTTP Request
+include::{snippets}/user-controller-docs-test/get-profile/http-request.adoc[]
+
+==== 3. HTTP Request Headers
+// include::{snippets}/user-controller-docs-test/delete-image/request-headers.adoc[]
+
+==== 4. HTTP Request Parameters
+
+===== 1) Path Parameters
+// include::{snippets}/user-controller-docs-test/delete-image/path-parameters.adoc[]
+
+===== 2) Query Parameters
+include::{snippets}/user-controller-docs-test/get-profile/query-parameters.adoc[]
+
+===== 3) Form Parameters
+// include::{snippets}/user-controller-docs-test/delete-image/form-parameters.adoc[]
+
+==== 5. HTTP Request Body
+include::{snippets}/user-controller-docs-test/get-profile/request-body.adoc[]
+// include::{snippets}/user-controller-docs-test/delete-image/request-fields.adoc[]
+
+==== 6. HTTP Response Body
+include::{snippets}/user-controller-docs-test/get-profile/response-body.adoc[]
+include::{snippets}/user-controller-docs-test/get-profile/response-fields.adoc[]

--- a/src/main/java/com/sevenstars/roome/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/sevenstars/roome/domain/profile/repository/ProfileRepository.java
@@ -12,6 +12,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByUser(User user);
 
     @Query("SELECT p FROM Profile p " +
+            "LEFT JOIN FETCH p.user u " +
             "LEFT JOIN FETCH p.color " +
             "WHERE p.user.id = :userId")
     Optional<Profile> findByUserId(Long userId);

--- a/src/main/java/com/sevenstars/roome/domain/profile/response/ProfileResponse.java
+++ b/src/main/java/com/sevenstars/roome/domain/profile/response/ProfileResponse.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ProfileResponse {
 
-    private final Long id;
+    private final String nickname;
     private final ProfileState state;
     private final String count;
     private final List<Genre> preferredGenres;
@@ -41,7 +41,7 @@ public class ProfileResponse {
                                      List<Element> deviceLockPreferences,
                                      List<Element> activities,
                                      List<Element> themeDislikedFactors) {
-        return new ProfileResponse(profile.getId(),
+        return new ProfileResponse(profile.getUser().getNickname(),
                 profile.getState(),
                 profile.getCount(),
                 preferredGenres.stream().map(Genre::from).collect(Collectors.toList()),

--- a/src/main/java/com/sevenstars/roome/domain/user/controller/UserController.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.sevenstars.roome.domain.user.controller;
 
+import com.sevenstars.roome.domain.profile.response.ProfileResponse;
 import com.sevenstars.roome.domain.user.request.NicknameRequest;
 import com.sevenstars.roome.domain.user.request.TermsAgreementRequest;
 import com.sevenstars.roome.domain.user.response.UserImageResponse;
@@ -54,5 +55,10 @@ public class UserController {
     public ApiResponse<Void> deleteImage(@AuthenticationPrincipal Long id) {
         userService.deleteImage(id);
         return ApiResponse.success();
+    }
+
+    @GetMapping("/users/profile")
+    public ApiResponse<ProfileResponse> getUserProfile(@RequestParam String nickname) {
+        return ApiResponse.success(userService.getUserProfile(nickname));
     }
 }

--- a/src/main/java/com/sevenstars/roome/domain/user/entity/User.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/entity/User.java
@@ -75,7 +75,7 @@ public class User extends BaseTimeEntity {
             throw new CustomClientErrorException(USER_NICKNAME_EMPTY);
         }
 
-        if (!nickname.matches("^[가-힣a-zA-Z0-9]+$")) {
+        if (!nickname.matches("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]+$")) {
             throw new CustomClientErrorException(USER_NICKNAME_CAN_CONTAIN_KOREAN_ENGLISH_OR_NUMBERS);
         }
 

--- a/src/main/java/com/sevenstars/roome/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByServiceIdAndServiceUserId(String serviceId, String serviceUserId);
 
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/sevenstars/roome/domain/user/service/UserService.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/service/UserService.java
@@ -1,7 +1,9 @@
 package com.sevenstars.roome.domain.user.service;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.sevenstars.roome.domain.common.repository.ForbiddenWordRepository;
 import com.sevenstars.roome.domain.profile.entity.Profile;
 import com.sevenstars.roome.domain.profile.entity.ProfileState;
@@ -216,7 +218,10 @@ public class UserService {
         deleteImage(id);
 
         try {
-            amazonS3.putObject(userImageBucket, fileName, file.getInputStream(), metadata);
+            PutObjectRequest request = new PutObjectRequest(userImageBucket, fileName, file.getInputStream(), metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(request);
+
         } catch (IOException e) {
             throw new CustomServerErrorException(FILE_UPLOAD_FAILED);
         }

--- a/src/main/java/com/sevenstars/roome/global/config/S3Config.java
+++ b/src/main/java/com/sevenstars/roome/global/config/S3Config.java
@@ -2,6 +2,7 @@ package com.sevenstars.roome.global.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,13 +17,22 @@ public class S3Config {
     private String secretKey;
     @Value("${cloud.aws.region.static}")
     private String region;
+    @Value("${cloud.aws.s3.endpoint:}")
+    private String endpoint;
 
     @Bean
     public AmazonS3Client amazonS3Client() {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .build();
+
+        AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials));
+
+        if (endpoint == null || endpoint.isEmpty()) {
+            builder.withRegion(region);
+        } else {
+            builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region));
+        }
+
+        return (AmazonS3Client) builder.build();
     }
 }

--- a/src/main/java/com/sevenstars/roome/global/config/SecurityConfig.java
+++ b/src/main/java/com/sevenstars/roome/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -41,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers(antMatcher("/swagger-ui/**")).permitAll()
                         .requestMatchers(antMatcher("/swagger-resources/**")).permitAll()
                         .requestMatchers(antMatcher("/v3/api-docs/**")).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/users/profile").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(customizer -> customizer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/test/java/com/sevenstars/roome/docs/user/ProfileControllerDocsTest.java
+++ b/src/test/java/com/sevenstars/roome/docs/user/ProfileControllerDocsTest.java
@@ -237,7 +237,7 @@ public class ProfileControllerDocsTest extends RestDocsTest {
                 "#73549D");
 
         ProfileResponse response = new ProfileResponse(
-                1L,
+                "루미",
                 COMPLETE,
                 "150",
                 genres,
@@ -262,8 +262,8 @@ public class ProfileControllerDocsTest extends RestDocsTest {
                 .andDo(restDocs.document(
                         responseFields(responseCommon())
                                 .and(
-                                        fieldWithPath("data.id").type(JsonFieldType.NUMBER)
-                                                .description("프로필 ID"),
+                                        fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                                                .description("사용자 닉네임"),
                                         fieldWithPath("data.state").type(JsonFieldType.STRING)
                                                 .description("프로필 상태"),
                                         fieldWithPath("data.count").type(JsonFieldType.STRING)

--- a/src/test/java/com/sevenstars/roome/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/com/sevenstars/roome/docs/user/UserControllerDocsTest.java
@@ -1,6 +1,8 @@
 package com.sevenstars.roome.docs.user;
 
 import com.sevenstars.roome.docs.RestDocsTest;
+import com.sevenstars.roome.domain.profile.entity.Mbti;
+import com.sevenstars.roome.domain.profile.response.ProfileResponse;
 import com.sevenstars.roome.domain.user.controller.UserController;
 import com.sevenstars.roome.domain.user.entity.User;
 import com.sevenstars.roome.domain.user.entity.UserState;
@@ -14,8 +16,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.sevenstars.roome.domain.profile.entity.ProfileState.COMPLETE;
+import static com.sevenstars.roome.domain.profile.entity.color.ColorDirection.TOP_LEFT_TO_BOTTOM_RIGHT;
+import static com.sevenstars.roome.domain.profile.entity.color.ColorMode.GRADIENT;
+import static com.sevenstars.roome.domain.profile.entity.color.ColorShape.LINEAR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -25,6 +32,8 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -164,5 +173,149 @@ public class UserControllerDocsTest extends RestDocsTest {
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
                         responseFields(responseCommon())));
+    }
+
+    @DisplayName("프로필 정보 조회")
+    @Test
+    void getProfile() throws Exception {
+
+        // Given
+        List<ProfileResponse.Genre> genres = List.of(
+                new ProfileResponse.Genre(9L, "미스터리", "미스터리"),
+                new ProfileResponse.Genre(15L, "SF", "SF"));
+
+        List<ProfileResponse.Strength> strengths = List.of(
+                new ProfileResponse.Strength(4L, "집중력", "집중력"),
+                new ProfileResponse.Strength(8L, "침착함", "침착함"));
+
+        List<ProfileResponse.ImportantFactor> importantFactors = List.of(
+                new ProfileResponse.ImportantFactor(3L, "명확한 개연성", "명확한 개연성"),
+                new ProfileResponse.ImportantFactor(7L, "논리적인 문제", "논리적인 문제"));
+
+        ProfileResponse.HorrorThemePosition horrorThemePosition = new ProfileResponse.HorrorThemePosition(4L, "마지모탱", "마지모탱");
+
+        ProfileResponse.HintUsagePreference hintUsagePreference = new ProfileResponse.HintUsagePreference(2L, "최소한의 힌트만", "최소한의 힌트만");
+
+        ProfileResponse.DeviceLockPreference deviceLockPreference = new ProfileResponse.DeviceLockPreference(1L, "장치", "장치");
+
+        ProfileResponse.Activity activity = new ProfileResponse.Activity(3L, "낮은 활동성", "낮은 활동성");
+
+        List<ProfileResponse.DislikedFactor> dislikedFactors = List.of(
+                new ProfileResponse.DislikedFactor(2L, "노가다 문제", "노가다 문제"),
+                new ProfileResponse.DislikedFactor(6L, "높은 난이도", "높은 난이도"));
+
+        ProfileResponse.Color color = new ProfileResponse.Color(4L,
+                "Gradient Purple",
+                GRADIENT,
+                LINEAR,
+                TOP_LEFT_TO_BOTTOM_RIGHT,
+                "#2E2E8D",
+                "#73549D");
+
+        ProfileResponse response = new ProfileResponse(
+                "루미",
+                COMPLETE,
+                "150",
+                genres,
+                Mbti.ISFJ,
+                strengths,
+                importantFactors,
+                horrorThemePosition,
+                hintUsagePreference,
+                deviceLockPreference,
+                activity,
+                dislikedFactors,
+                color);
+
+        given(userService.getUserProfile(any()))
+                .willReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/users/profile")
+                        .queryParam("nickname", "루미"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        queryParameters(parameterWithName("nickname").description("닉네임")),
+                        responseFields(responseCommon())
+                                .and(
+                                        fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                                                .description("사용자 닉네임"),
+                                        fieldWithPath("data.state").type(JsonFieldType.STRING)
+                                                .description("프로필 상태"),
+                                        fieldWithPath("data.count").type(JsonFieldType.STRING)
+                                                .description("방 수"),
+                                        fieldWithPath("data.preferredGenres[]").type(JsonFieldType.ARRAY)
+                                                .description("선호 장르 목록"),
+                                        fieldWithPath("data.preferredGenres[].id").type(JsonFieldType.NUMBER)
+                                                .description("선호 장르 ID"),
+                                        fieldWithPath("data.preferredGenres[].title").type(JsonFieldType.STRING)
+                                                .description("선호 장르 제목"),
+                                        fieldWithPath("data.preferredGenres[].text").type(JsonFieldType.STRING)
+                                                .description("선호 장르 텍스트"),
+                                        fieldWithPath("data.mbti").type(JsonFieldType.STRING)
+                                                .description("MBTI"),
+                                        fieldWithPath("data.userStrengths[]").type(JsonFieldType.ARRAY)
+                                                .description("사용자 강점 목록"),
+                                        fieldWithPath("data.userStrengths[].id").type(JsonFieldType.NUMBER)
+                                                .description("사용자 강점 ID"),
+                                        fieldWithPath("data.userStrengths[].title").type(JsonFieldType.STRING)
+                                                .description("사용자 강점 제목"),
+                                        fieldWithPath("data.userStrengths[].text").type(JsonFieldType.STRING)
+                                                .description("사용자 강점 텍스트"),
+                                        fieldWithPath("data.themeImportantFactors[]").type(JsonFieldType.ARRAY)
+                                                .description("테마 중요 요소 목록"),
+                                        fieldWithPath("data.themeImportantFactors[].id").type(JsonFieldType.NUMBER)
+                                                .description("테마 중요 요소 ID"),
+                                        fieldWithPath("data.themeImportantFactors[].title").type(JsonFieldType.STRING)
+                                                .description("테마 중요 요소 제목"),
+                                        fieldWithPath("data.themeImportantFactors[].text").type(JsonFieldType.STRING)
+                                                .description("테마 중요 요소 텍스트"),
+                                        fieldWithPath("data.horrorThemePosition.id").type(JsonFieldType.NUMBER)
+                                                .description("공포 테마 포지션 ID"),
+                                        fieldWithPath("data.horrorThemePosition.title").type(JsonFieldType.STRING)
+                                                .description("공포 테마 포지션 제목"),
+                                        fieldWithPath("data.horrorThemePosition.text").type(JsonFieldType.STRING)
+                                                .description("공포 테마 포지션 텍스트"),
+                                        fieldWithPath("data.hintUsagePreference.id").type(JsonFieldType.NUMBER)
+                                                .description("힌트 사용 선호도 ID"),
+                                        fieldWithPath("data.hintUsagePreference.title").type(JsonFieldType.STRING)
+                                                .description("힌트 사용 선호도 제목"),
+                                        fieldWithPath("data.hintUsagePreference.text").type(JsonFieldType.STRING)
+                                                .description("힌트 사용 선호도 텍스트"),
+                                        fieldWithPath("data.deviceLockPreference.id").type(JsonFieldType.NUMBER)
+                                                .description("장치 자물쇠 선호도 ID"),
+                                        fieldWithPath("data.deviceLockPreference.title").type(JsonFieldType.STRING)
+                                                .description("장치 자물쇠 선호도 제목"),
+                                        fieldWithPath("data.deviceLockPreference.text").type(JsonFieldType.STRING)
+                                                .description("장치 자물쇠 선호도 텍스트"),
+                                        fieldWithPath("data.activity.id").type(JsonFieldType.NUMBER)
+                                                .description("활동성 ID"),
+                                        fieldWithPath("data.activity.title").type(JsonFieldType.STRING)
+                                                .description("활동성 제목"),
+                                        fieldWithPath("data.activity.text").type(JsonFieldType.STRING)
+                                                .description("활동성 텍스트"),
+                                        fieldWithPath("data.themeDislikedFactors[]").type(JsonFieldType.ARRAY)
+                                                .description("싫어하는 요소 목록"),
+                                        fieldWithPath("data.themeDislikedFactors[].id").type(JsonFieldType.NUMBER)
+                                                .description("싫어하는 요소 ID"),
+                                        fieldWithPath("data.themeDislikedFactors[].title").type(JsonFieldType.STRING)
+                                                .description("싫어하는 요소 제목"),
+                                        fieldWithPath("data.themeDislikedFactors[].text").type(JsonFieldType.STRING)
+                                                .description("싫어하는 요소 텍스트"),
+                                        fieldWithPath("data.color.id").type(JsonFieldType.NUMBER)
+                                                .description("색상 ID"),
+                                        fieldWithPath("data.color.title").type(JsonFieldType.STRING)
+                                                .description("색상 제목"),
+                                        fieldWithPath("data.color.mode").type(JsonFieldType.STRING)
+                                                .description("색상 모드"),
+                                        fieldWithPath("data.color.shape").type(JsonFieldType.STRING)
+                                                .description("색상 모양"),
+                                        fieldWithPath("data.color.direction").type(JsonFieldType.STRING)
+                                                .description("색상 방향"),
+                                        fieldWithPath("data.color.startColor").type(JsonFieldType.STRING)
+                                                .description("색상 시작 색상"),
+                                        fieldWithPath("data.color.endColor").type(JsonFieldType.STRING)
+                                                .description("색상 종료 색상"))));
     }
 }

--- a/src/test/java/com/sevenstars/roome/domain/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/sevenstars/roome/domain/profile/service/ProfileServiceTest.java
@@ -3,7 +3,6 @@ package com.sevenstars.roome.domain.profile.service;
 import com.sevenstars.roome.domain.profile.entity.Element;
 import com.sevenstars.roome.domain.profile.entity.Profile;
 import com.sevenstars.roome.domain.profile.entity.ProfileElement;
-import com.sevenstars.roome.domain.profile.entity.ProfileState;
 import com.sevenstars.roome.domain.profile.repository.ElementRepository;
 import com.sevenstars.roome.domain.profile.repository.ProfileElementRepository;
 import com.sevenstars.roome.domain.profile.repository.ProfileRepository;
@@ -17,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static com.sevenstars.roome.domain.profile.entity.ElementType.PREFERRED_GENRE;


### PR DESCRIPTION
# 개요
- 프로필 공유를 위해 프로필 조회 API 추가
- 사용자 인증 없이 닉네임으로 프로필을 조회할 수 있음
- 자음, 모음으로 닉네임 설정할 수 있도록 유효성 검사 로직 변경
- AWS S3 설정 다른 서비스도 호환되도록 개선
- 이미지 저장시 ACL Public Read 설정하도록 로직 변경

# 변경 내용
- 인증된 사용자 프로필 조회, 닉네임으로 사용자 프로필 조회시 리턴 값에 사용자 닉네임 추가
- 사용자 닉네임으로 프로필 조회 API 추가, 사용자 인증 필요 없음
- 자음, 모음으로 닉네임 설정할 수 있도록 유효성 검사 로직 변경
- AWS S3 설정 다른 서비스도 호환되도록 개선
  - application.yml에 cloud.aws.s3.endpoint 값이 있으면 해당 endpoint 설정
  - Naver Cloud 호환되도록 추가함
- 이미지 저장시 ACL Public Read 설정하도록 로직 변경
  - Naver Cloud 호환되도록 추가함
  - AWS는 콘솔에서 버킷 정책으로 설정 가능하나 Naver Cloud는 ACL로 설정해야함