### PR TITLE
[Feat] 회원탈퇴 API 변경, 인증 관련 API URL prefix 추가

### DIFF
--- a/src/docs/asciidoc/api/auth/auth.adoc
+++ b/src/docs/asciidoc/api/auth/auth.adoc
@@ -91,29 +91,29 @@ include::{snippets}/auth-controller-docs-test/sign-out/response-fields.adoc[]
 === 탈퇴
 
 ==== 1. Curl Request
-include::{snippets}/auth-controller-docs-test/withdraw/curl-request.adoc[]
+include::{snippets}/auth-controller-docs-test/deactivate/curl-request.adoc[]
 
 ==== 2. HTTP Request
-include::{snippets}/auth-controller-docs-test/withdraw/http-request.adoc[]
+include::{snippets}/auth-controller-docs-test/deactivate/http-request.adoc[]
 
 ==== 3. HTTP Request Headers
-// include::{snippets}/auth-controller-docs-test/withdraw/request-headers.adoc[]
+// include::{snippets}/auth-controller-docs-test/deactivate/request-headers.adoc[]
 
 ==== 4. HTTP Request Parameters
 
 ===== 1) Path Parameters
-// include::{snippets}/auth-controller-docs-test/withdraw/path-parameters.adoc[]
+// include::{snippets}/auth-controller-docs-test/deactivate/path-parameters.adoc[]
 
 ===== 2) Query Parameters
-// include::{snippets}/auth-controller-docs-test/withdraw/query-parameters.adoc[]
+// include::{snippets}/auth-controller-docs-test/deactivate/query-parameters.adoc[]
 
 ===== 3) Form Parameters
-// include::{snippets}/auth-controller-docs-test/withdraw/form-parameters.adoc[]
+// include::{snippets}/auth-controller-docs-test/deactivate/form-parameters.adoc[]
 
 ==== 5. HTTP Request Body
-include::{snippets}/auth-controller-docs-test/withdraw/request-body.adoc[]
-// include::{snippets}/auth-controller-docs-test/withdraw/request-fields.adoc[]
+include::{snippets}/auth-controller-docs-test/deactivate/request-body.adoc[]
+// include::{snippets}/auth-controller-docs-test/deactivate/request-fields.adoc[]
 
 ==== 6. HTTP Response Body
-include::{snippets}/auth-controller-docs-test/withdraw/response-body.adoc[]
-include::{snippets}/auth-controller-docs-test/withdraw/response-fields.adoc[]
+include::{snippets}/auth-controller-docs-test/deactivate/response-body.adoc[]
+include::{snippets}/auth-controller-docs-test/deactivate/response-fields.adoc[]

--- a/src/main/java/com/sevenstars/roome/domain/user/entity/UserDeactivationReason.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/entity/UserDeactivationReason.java
@@ -1,0 +1,30 @@
+package com.sevenstars.roome.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class UserDeactivationReason {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String reason;
+
+    private String content;
+
+    public UserDeactivationReason(String reason, String content) {
+        this.reason = StringUtils.hasText(reason) ? reason : "";
+        this.content = StringUtils.hasText(content) ? content : "";
+    }
+}

--- a/src/main/java/com/sevenstars/roome/domain/user/repository/UserDeactivationReasonRepository.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/repository/UserDeactivationReasonRepository.java
@@ -1,0 +1,7 @@
+package com.sevenstars.roome.domain.user.repository;
+
+import com.sevenstars.roome.domain.user.entity.UserDeactivationReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDeactivationReasonRepository extends JpaRepository<UserDeactivationReason, Long> {
+}

--- a/src/main/java/com/sevenstars/roome/domain/user/service/UserService.java
+++ b/src/main/java/com/sevenstars/roome/domain/user/service/UserService.java
@@ -13,7 +13,9 @@ import com.sevenstars.roome.domain.profile.response.ProfileResponse;
 import com.sevenstars.roome.domain.profile.service.ProfileService;
 import com.sevenstars.roome.domain.user.entity.TermsAgreement;
 import com.sevenstars.roome.domain.user.entity.User;
+import com.sevenstars.roome.domain.user.entity.UserDeactivationReason;
 import com.sevenstars.roome.domain.user.repository.TermsAgreementRepository;
+import com.sevenstars.roome.domain.user.repository.UserDeactivationReasonRepository;
 import com.sevenstars.roome.domain.user.repository.UserRepository;
 import com.sevenstars.roome.domain.user.request.NicknameRequest;
 import com.sevenstars.roome.domain.user.request.TermsAgreementRequest;
@@ -45,6 +47,7 @@ public class UserService {
     private static final String USER_IMAGE_PATH = "/users/images";
     private final ProfileService profileService;
     private final UserRepository userRepository;
+    private final UserDeactivationReasonRepository userDeactivationReasonRepository;
     private final TermsAgreementRepository termsAgreementRepository;
     private final ProfileRepository profileRepository;
     private final ProfileElementRepository profileElementRepository;
@@ -93,7 +96,7 @@ public class UserService {
     }
 
     @Transactional
-    public void withdraw(Long id) {
+    public void deactivate(Long id, String reason, String content) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new CustomClientErrorException(USER_NOT_FOUND));
 
@@ -118,6 +121,10 @@ public class UserService {
 
         // User
         userRepository.delete(user);
+
+        if (StringUtils.hasText(reason) || StringUtils.hasText(content)) {
+            userDeactivationReasonRepository.save(new UserDeactivationReason(reason, content));
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sevenstars/roome/global/auth/controller/AuthController.java
+++ b/src/main/java/com/sevenstars/roome/global/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.sevenstars.roome.global.auth.controller;
 
+import com.sevenstars.roome.global.auth.request.DeactivateRequest;
 import com.sevenstars.roome.global.auth.request.SignInRequest;
 import com.sevenstars.roome.global.auth.request.TokenRequest;
-import com.sevenstars.roome.global.auth.request.WithdrawalRequest;
 import com.sevenstars.roome.global.auth.response.TokenResponse;
 import com.sevenstars.roome.global.auth.service.LoginService;
 import com.sevenstars.roome.global.common.response.ApiResponse;
@@ -25,27 +25,27 @@ public class AuthController {
     private final LoginService loginService;
     private final JwtTokenService tokenService;
 
-    @PostMapping("/signin")
+    @PostMapping("/auth/signin")
     public ApiResponse<TokenResponse> signIn(@RequestBody @Valid SignInRequest request) {
         return ApiResponse.success(loginService.signIn(request));
     }
 
-    @PostMapping("/token")
+    @PostMapping("/auth/token")
     public ApiResponse<TokenResponse> getToken(@RequestBody @Valid TokenRequest request) {
         return ApiResponse.success(tokenService.getToken(request));
     }
 
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/signout")
+    @PostMapping("/auth/signout")
     public ApiResponse<Void> signOut(@AuthenticationPrincipal Long userId) {
         tokenService.delete(userId);
         return ApiResponse.success();
     }
 
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/withdrawal")
-    public ApiResponse<Void> withdraw(@AuthenticationPrincipal Long userId, @RequestBody @Valid WithdrawalRequest request) {
-        loginService.withdraw(userId, request);
+    @PostMapping("/auth/deactivate")
+    public ApiResponse<Void> deactivate(@AuthenticationPrincipal Long userId, @RequestBody @Valid DeactivateRequest request) {
+        loginService.deactivate(userId, request);
         return ApiResponse.success();
     }
 

--- a/src/main/java/com/sevenstars/roome/global/auth/request/DeactivateRequest.java
+++ b/src/main/java/com/sevenstars/roome/global/auth/request/DeactivateRequest.java
@@ -4,8 +4,10 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class WithdrawalRequest {
+public class DeactivateRequest {
     @NotNull
     private String provider;
     private String code;
+    private String reason;
+    private String content;
 }

--- a/src/main/java/com/sevenstars/roome/global/auth/service/AbstractLoginService.java
+++ b/src/main/java/com/sevenstars/roome/global/auth/service/AbstractLoginService.java
@@ -8,8 +8,8 @@ import com.sevenstars.roome.global.auth.config.OAuth2ProviderProperties;
 import com.sevenstars.roome.global.auth.entity.OAuth2Provider;
 import com.sevenstars.roome.global.auth.entity.OAuth2ProviderToken;
 import com.sevenstars.roome.global.auth.entity.TokenHeader;
+import com.sevenstars.roome.global.auth.request.DeactivateRequest;
 import com.sevenstars.roome.global.auth.request.SignInRequest;
-import com.sevenstars.roome.global.auth.request.WithdrawalRequest;
 import com.sevenstars.roome.global.auth.response.Key;
 import com.sevenstars.roome.global.auth.response.OAuth2TokenResponse;
 import com.sevenstars.roome.global.auth.response.PublicKeyResponse;
@@ -69,15 +69,17 @@ public abstract class AbstractLoginService {
         return tokenService.issue(userId);
     }
 
-    public void withdraw(Long id, WithdrawalRequest request) {
+    public void deactivate(Long id, DeactivateRequest request) {
 
         String code = request.getCode();
+        String reason = request.getReason();
+        String content = request.getContent();
 
         if (StringUtils.hasText(code)) {
             revokeToken(code);
         }
 
-        userService.withdraw(id);
+        userService.deactivate(id, reason, content);
     }
 
     protected OAuth2ProviderToken getToken(String code) {

--- a/src/main/java/com/sevenstars/roome/global/auth/service/LoginService.java
+++ b/src/main/java/com/sevenstars/roome/global/auth/service/LoginService.java
@@ -1,8 +1,8 @@
 package com.sevenstars.roome.global.auth.service;
 
 import com.sevenstars.roome.global.auth.entity.OAuth2Provider;
+import com.sevenstars.roome.global.auth.request.DeactivateRequest;
 import com.sevenstars.roome.global.auth.request.SignInRequest;
-import com.sevenstars.roome.global.auth.request.WithdrawalRequest;
 import com.sevenstars.roome.global.auth.response.TokenResponse;
 import com.sevenstars.roome.global.common.exception.CustomClientErrorException;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +34,7 @@ public class LoginService {
         return oAuth2LoginService.signIn(request);
     }
 
-    public void withdraw(Long id, WithdrawalRequest request) {
+    public void deactivate(Long id, DeactivateRequest request) {
 
         OAuth2Provider oAuth2Provider = Arrays.stream(OAuth2Provider.values())
                 .filter(provider -> provider.getName().equals(request.getProvider()))
@@ -46,6 +46,6 @@ public class LoginService {
                 .findAny()
                 .orElseThrow(() -> new CustomClientErrorException(PROVIDER_NOT_FOUND));
 
-        oAuth2LoginService.withdraw(id, request);
+        oAuth2LoginService.deactivate(id, request);
     }
 }

--- a/src/main/java/com/sevenstars/roome/global/auth/service/OAuth2LoginService.java
+++ b/src/main/java/com/sevenstars/roome/global/auth/service/OAuth2LoginService.java
@@ -1,8 +1,8 @@
 package com.sevenstars.roome.global.auth.service;
 
 import com.sevenstars.roome.global.auth.entity.OAuth2Provider;
+import com.sevenstars.roome.global.auth.request.DeactivateRequest;
 import com.sevenstars.roome.global.auth.request.SignInRequest;
-import com.sevenstars.roome.global.auth.request.WithdrawalRequest;
 import com.sevenstars.roome.global.auth.response.TokenResponse;
 
 public interface OAuth2LoginService {
@@ -10,5 +10,5 @@ public interface OAuth2LoginService {
 
     TokenResponse signIn(SignInRequest request);
 
-    void withdraw(Long id, WithdrawalRequest request);
+    void deactivate(Long id, DeactivateRequest request);
 }

--- a/src/main/java/com/sevenstars/roome/global/config/SecurityConfig.java
+++ b/src/main/java/com/sevenstars/roome/global/config/SecurityConfig.java
@@ -35,8 +35,8 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/health").permitAll()
-                        .requestMatchers("/signin").permitAll()
-                        .requestMatchers("/token").permitAll()
+                        .requestMatchers("/auth/signin").permitAll()
+                        .requestMatchers("/auth/token").permitAll()
                         .requestMatchers("/docs/index.html").permitAll()
                         .requestMatchers(antMatcher("/login/**")).permitAll()
                         .requestMatchers(antMatcher("/swagger-ui/**")).permitAll()

--- a/src/test/java/com/sevenstars/roome/docs/auth/AuthControllerDocsTest.java
+++ b/src/test/java/com/sevenstars/roome/docs/auth/AuthControllerDocsTest.java
@@ -4,7 +4,7 @@ import com.sevenstars.roome.docs.RestDocsTest;
 import com.sevenstars.roome.global.auth.controller.AuthController;
 import com.sevenstars.roome.global.auth.request.SignInRequest;
 import com.sevenstars.roome.global.auth.request.TokenRequest;
-import com.sevenstars.roome.global.auth.request.WithdrawalRequest;
+import com.sevenstars.roome.global.auth.request.DeactivateRequest;
 import com.sevenstars.roome.global.auth.response.TokenResponse;
 import com.sevenstars.roome.global.auth.service.LoginService;
 import com.sevenstars.roome.global.jwt.service.JwtTokenService;
@@ -48,7 +48,7 @@ public class AuthControllerDocsTest extends RestDocsTest {
         request.setIdToken("Identity Token");
 
         // When & Then
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/signin")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/auth/signin")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON))
                 .andDo(print())
@@ -75,7 +75,7 @@ public class AuthControllerDocsTest extends RestDocsTest {
         request.setRefreshToken("Refresh Token");
 
         // When & Then
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/token")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/auth/token")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON))
                 .andDo(print())
@@ -96,7 +96,7 @@ public class AuthControllerDocsTest extends RestDocsTest {
         // Given
 
         // When & Then
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/signout")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/auth/signout")
                         .header(AUTHORIZATION, "Bearer {token}"))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -106,15 +106,17 @@ public class AuthControllerDocsTest extends RestDocsTest {
 
     @DisplayName("탈퇴")
     @Test
-    void withdraw() throws Exception {
+    void deactivate() throws Exception {
 
         // Given
-        WithdrawalRequest request = new WithdrawalRequest();
+        DeactivateRequest request = new DeactivateRequest();
         request.setProvider("google");
         request.setCode("Authorization Code");
+        request.setReason("원하는 기능이 없어요");
+        request.setContent("방탈출 메이트 구하는 기능이 없어요!");
 
         // When & Then
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/withdrawal")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/auth/deactivate")
                         .header(AUTHORIZATION, "Bearer {token}")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON))


### PR DESCRIPTION
# 개요
- 인증 관련 API URL prefix 추가
- 탈퇴 API URL 변경
- 회원탈퇴 API에 탈퇴 사유 필드 추가

# 변경 내용
- 인증 관련 API URL prefix 추가, 탈퇴 API URL 변경
  - /signin -> /auth/signin
  - /token -> /auth/token
  - /signout -> /auth/signout
  - /withdrawal -> /auth/deactivate
- 탈퇴 API에 reason, content 필드 추가